### PR TITLE
Handle upgrade p3 to p4 case

### DIFF
--- a/config/base_boxes.yaml
+++ b/config/base_boxes.yaml
@@ -7,6 +7,8 @@ shells:
     shell: '/vagrant/shells/runcible.sh'
   katello_p4_shell: &katello_p4_shell
     shell: '/vagrant/shells/katello_p4_repos.sh; foreman-installer -v --scenario katello --foreman-admin-password=changeme'
+  katello_p3_shell: &katello_p3_shell
+    shell: '/vagrant/shells/katello_p3.sh; foreman-installer -v --scenario katello --foreman-admin-password=changeme'
   capsule_p4_shell: &capsule_p4_shell
     shell: '/vagrant/shells/katello_p4_repos.sh'
 
@@ -80,6 +82,10 @@ boxes:
     box: centos7
     <<: *runcible_shell
     privileged: false
+
+  centos7-katello-p3:
+    box: centos7
+    <<: *katello_p3_shell
 
   centos7-katello-p4:
     box: centos7

--- a/shells/katello_p3.sh
+++ b/shells/katello_p3.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+# This script creates a puppet 3 katello that is ready for upgrade to puppet 4
+
+yum -y localinstall http://yum.theforeman.org/releases/1.12/el7/x86_64/foreman-release.rpm
+yum -y localinstall http://fedorapeople.org/groups/katello/releases/yum/3.1/katello/el7/x86_64/katello-repos-latest.rpm
+yum -y localinstall https://yum.puppetlabs.com/puppetlabs-release-el-7.noarch.rpm # puppet 3
+yum -y localinstall http://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
+yum -y install foreman-release-scl
+yum -y install katello
+yum -y install puppet
+
+yum install -y haveged; service haveged start # saves some time on tomcat startup, worth it:)
+
+setenforce 0  # uggggh! stopdisablingselinux.com :-P
+
+# XXX: this will go away on its own after we are using nightlies instead of 3.1
+mkdir /usr/share/katello-installer-base/modules/OLD
+for r in certs katello pulp qpid crane capsule candlepin common service_wait; do
+  mv /usr/share/katello-installer-base/modules/$r /usr/share/katello-installer-base/modules/OLD/
+  git clone https://github.com/Katello/puppet-$r /usr/share/katello-installer-base/modules/$r
+done
+
+# remove once nightlies are back
+cd /usr/share/katello-installer-base/
+curl https://patch-diff.githubusercontent.com/raw/Katello/katello-installer/pull/380.patch | patch -p1
+curl https://patch-diff.githubusercontent.com/raw/Katello/katello-installer/pull/381.patch | patch -p1

--- a/upgrade_p3_to_p4.sh
+++ b/upgrade_p3_to_p4.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+katello-service stop
+
+# Upgrade puppet 3 to puppet 4
+yum -y localinstall https://yum.puppetlabs.com/puppetlabs-release-pc1-el-7.noarch.rpm # puppet 4!!!
+yum remove -y puppet-server # remove old style puppet master
+yum -y install puppetserver #this upgrades puppet, replaces agent too
+
+# Copy puppet environments
+cp -rfp /etc/puppet/environments/* /etc/puppetlabs/code/environments
+
+# Restore puppet 3 info - ssl certs and cache data
+mv /var/lib/puppet/ssl /etc/puppetlabs/puppet
+mv /var/lib/puppet/foreman_cache_data /opt/puppetlabs/puppet/cache/
+
+# Disable HTTP puppet to free up port
+rm -f /etc/httpd/conf.d/25-puppet.conf
+sed -ie '/Listen 8140/d' /etc/httpd/conf/ports.conf
+service httpd restart
+
+# we need "puppet help strings" to work so kafo_parsers picks up the parser
+/opt/puppetlabs/bin/puppet module install puppetlabs-strings
+/opt/puppetlabs/puppet/bin/gem install yard
+
+# patches needed:
+cd /;
+curl http://paste.fedoraproject.org/397071/35937146/raw/ | patch -p0 # hack passenger module issue
+curl http://paste.fedoraproject.org/397340/46980677/raw/ | patch -p0 # hack env dir override
+
+
+# Expose server type https://github.com/Katello/puppet-capsule/pull/90
+cd /usr/share/katello-installer-base/modules/capsule
+wget https://github.com/Katello/puppet-capsule/pull/90.patch
+git apply 90.patch
+
+
+# Run installer again
+foreman-installer -v \
+  --capsule-puppet-server-implementation=puppetserver \
+  --reset-foreman-puppet-home \
+  --reset-foreman-puppet-ssldir \
+  --reset-foreman-proxy-puppet-ssl-ca \
+  --reset-foreman-proxy-puppet-ssl-cert \
+  --reset-foreman-proxy-puppet-ssl-key \
+  --reset-foreman-proxy-puppetdir \
+  --reset-foreman-proxy-ssldir \
+  --reset-foreman-puppet-home
+
+service foreman-proxy restart
+hammer -u admin -p changeme proxy refresh-features --name $HOSTNAME
+
+# P4 client should run successfully:
+/opt/puppetlabs/bin/puppet agent --test


### PR DESCRIPTION
Adapted from http://projects.theforeman.org/projects/foreman/wiki/Upgrading_from_Puppet_3_to_4

This adds a centos7-katello-p3 box, that creates a puppet 3 box ready for upgrade to puppet 4.  It also includes a script to run on the box to get to p4 (upgrade_p3_to_p4.sh).

Not really sure what the best way to approach automating the upgrade for users,  Foreman has just gone with saying "here's a wiki, you're on your own".  I don't think we can really do that for downstream right? So maybe we need to create an installer hook that runs if the user gives it some option like `--upgrade-puppet`? 
